### PR TITLE
fix: add missing replace directive for mastodon plugin

### DIFF
--- a/templates/go.mod.tmpl
+++ b/templates/go.mod.tmpl
@@ -12,3 +12,5 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	google.golang.org/protobuf v1.31.0
 )
+
+replace github.com/mattn/go-mastodon => github.com/turbot/go-mastodon v0.0.1


### PR DESCRIPTION
- Add replace directive for github.com/mattn/go-mastodon => github.com/turbot/go-mastodon v0.0.1
- This fixes build failures for plugins that depend on forked libraries
- The mastodon plugin requires the turbot fork which has additional methods
- Without this directive, builds fall back to the original library missing required methods

Fixes build issues with steampipe-plugin-mastodon@v1.2.0 and similar plugins